### PR TITLE
Fix unit test ITF

### DIFF
--- a/src/test/mempooltxdb_tests.cpp
+++ b/src/test/mempooltxdb_tests.cpp
@@ -108,10 +108,8 @@ BOOST_AUTO_TEST_CASE(DoubleWriteToTxDB)
     {
         BOOST_CHECK(txdb.AddTransactions({e.GetSharedTx()}));
     }
-    BOOST_WARN_EQUAL(txdb.GetDiskUsage(), totalSize(entries));
-    BOOST_WARN_EQUAL(txdb.GetTxCount(), entries.size());
-    BOOST_CHECK_GE(txdb.GetDiskUsage(), totalSize(entries));
-    BOOST_CHECK_GE(txdb.GetTxCount(), entries.size());
+    BOOST_CHECK_EQUAL(txdb.GetDiskUsage(), totalSize(entries));
+    BOOST_CHECK_EQUAL(txdb.GetTxCount(), entries.size());
     for (const auto& e : entries)
     {
         CTransactionRef _;
@@ -191,8 +189,8 @@ BOOST_AUTO_TEST_CASE(BadDeleteFromTxDB)
                 {e[1].GetTxId(), e[1].GetTxSize()},
                 {e[2].GetTxId(), e[2].GetTxSize()}
             }));
-    BOOST_WARN_EQUAL(txdb.GetDiskUsage(), 0U);
-    BOOST_WARN_EQUAL(txdb.GetTxCount(), 0U);
+    BOOST_CHECK_EQUAL(txdb.GetDiskUsage(), 0U);
+    BOOST_CHECK_EQUAL(txdb.GetTxCount(), 0U);
 }
 
 BOOST_AUTO_TEST_CASE(ClearTxDB)


### PR DESCRIPTION
The method CMempoolTxDB::AddTransactions does not check whether any of the transactions being added are already in the DB. This does matter to the underlying levelDB, but if duplicate txns are added using this method then the disk usage and txn count accounting values calculated by this class will be wrong. This commit changes the behaviour of this method to only update the accounting information for transactions that are not clready in the DB.

Also make corresponding changes to CMempoolTxDB::RemoveTransactions to fix the same issue there.

Note that the documentation for this class specifies it should only be used from a single threaded context.